### PR TITLE
[Trimming] Feature switch: QueryPropertyAttribute support

### DIFF
--- a/docs/design/FeatureSwitches.md
+++ b/docs/design/FeatureSwitches.md
@@ -5,9 +5,15 @@ Certain features of MAUI can be enabled or disabled using feature switches. The 
 | MSBuild Property Name | AppContext Setting | Description |
 |-|-|-|
 | MauiXamlRuntimeParsingSupport | Microsoft.Maui.RuntimeFeature.IsXamlRuntimeParsingSupported | When disabled, all XAML loading at runtime will throw an exception. This will affect usage of APIs such as the `LoadFromXaml` extension method. This feature can be safely turned off when all XAML resources are compiled using XamlC (see [XAML compilation](https://learn.microsoft.com/en-us/dotnet/maui/xaml/xamlc)). This feature is enabled by default for all configurations except for NativeAOT. |
+| MauiQueryPropertyAttributeSupport | Microsoft.Maui.RuntimeFeature.IsQueryPropertyAttributeSupported | When disabled, using `[QueryProperty]` attributes will throw an exception when navigating to the page. Instead of using `[QueryProperty]`, implement the `IQueryAttributable` interface on all affected pages and binding context objects. This feature is enabled by default for all configurations except for NativeAOT. |
 
 ## MauiXamlRuntimeParsingSupport
 
 When this feature is disabled, the following APIs are affected:
 - [`LoadFromXaml` extension methods](https://learn.microsoft.com/en-us/dotnet/maui/xaml/runtime-load) will throw runtime exceptions.
 - [Disabling XAML compilation](https://learn.microsoft.com/en-us/dotnet/maui/xaml/xamlc#disable-xaml-compilation) using `[XamlCompilation(XamlCompilationOptions.Skip)]` on pages and controls or whole assemblies will cause runtime exceptions.
+
+## MauiQueryPropertyAttributeSupport
+
+When this feature is disabled, the following functionality is affected:
+- Navigating to pages annotated with [`QueryPropertyAttribute`](https://learn.microsoft.com/en-us/dotnet/maui/fundamentals/shell/navigation?view=net-maui-8.0#process-navigation-data-using-query-property-attributes) will throw runtime exceptions.

--- a/src/Controls/src/Build.Tasks/nuget/buildTransitive/netstandard2.0/Microsoft.Maui.Controls.targets
+++ b/src/Controls/src/Build.Tasks/nuget/buildTransitive/netstandard2.0/Microsoft.Maui.Controls.targets
@@ -209,11 +209,16 @@
   <Target Name="_MauiPrepareForILLink" BeforeTargets="PrepareForILLink">
     <PropertyGroup>
       <MauiXamlRuntimeParsingSupport Condition="'$(MauiXamlRuntimeParsingSupport)' == '' and '$(PublishAot)' == 'true'">false</MauiXamlRuntimeParsingSupport>
+      <MauiQueryPropertyAttributeSupport Condition="'$(MauiQueryPropertyAttributeSupport)' == '' and '$(PublishAot)' == 'true'">false</MauiQueryPropertyAttributeSupport>
     </PropertyGroup>
     <ItemGroup>
       <RuntimeHostConfigurationOption Include="Microsoft.Maui.RuntimeFeature.IsXamlRuntimeParsingSupported"
                                       Condition="'$(MauiXamlRuntimeParsingSupport)' != ''"
                                       Value="$(MauiXamlRuntimeParsingSupport)"
+                                      Trim="true" />
+      <RuntimeHostConfigurationOption Include="Microsoft.Maui.RuntimeFeature.IsQueryPropertyAttributeSupported"
+                                      Condition="'$(MauiQueryPropertyAttributeSupport)' != ''"
+                                      Value="$(MauiQueryPropertyAttributeSupport)"
                                       Trim="true" />
     </ItemGroup>
   </Target>

--- a/src/Controls/src/Core/Shell/ShellContent.cs
+++ b/src/Controls/src/Core/Shell/ShellContent.cs
@@ -63,7 +63,9 @@ namespace Microsoft.Maui.Controls
 			if (template == null)
 			{
 				if (content is Page page)
+				{
 					result = page;
+				}
 			}
 			else
 			{
@@ -84,19 +86,29 @@ namespace Microsoft.Maui.Controls
 			}
 
 			if (result == null)
+			{
 				throw new InvalidOperationException($"No Content found for {nameof(ShellContent)}, Title:{Title}, Route {Route}");
+			}
 
 			if (result is TabbedPage)
+			{
 				throw new NotSupportedException($"Shell is currently not compatible with TabbedPage. Please use TabBar, Tab or switch to using NavigationPage for your {Application.Current}.MainPage");
+			}
 
 			if (result is FlyoutPage)
+			{
 				throw new NotSupportedException("Shell is currently not compatible with FlyoutPage.");
+			}
 
 			if (result is NavigationPage)
+			{
 				throw new NotSupportedException("Shell is currently not compatible with NavigationPage. Shell has Navigation built in and doesn't require a NavigationPage.");
+			}
 
 			if (GetValue(QueryAttributesProperty) is ShellRouteParameters delayedQueryParams)
+			{
 				result.SetValue(QueryAttributesProperty, delayedQueryParams);
+			}
 
 			return result;
 		}
@@ -123,7 +135,9 @@ namespace Microsoft.Maui.Controls
 			// only fire Appearing when the Content Page exists on the ShellContent
 			var content = ContentCache ?? Content;
 			if (content == null)
+			{
 				return;
+			}
 
 			base.SendAppearing();
 
@@ -133,7 +147,9 @@ namespace Microsoft.Maui.Controls
 		void SendPageAppearing(Page page)
 		{
 			if (page == null)
+			{
 				return;
+			}
 
 			if (page.Parent == null)
 			{
@@ -173,7 +189,9 @@ namespace Microsoft.Maui.Controls
 		void OnPagePropertyChanged(object sender, PropertyChangedEventArgs e)
 		{
 			if (e.PropertyName == Page.IsVisibleProperty.PropertyName)
+			{
 				_isPageVisibleChanged?.Invoke(this, EventArgs.Empty);
+			}
 		}
 
 		Page ContentCache
@@ -182,12 +200,16 @@ namespace Microsoft.Maui.Controls
 			set
 			{
 				if (_contentCache == value)
+				{
 					return;
+				}
 
 				var oldCache = _contentCache;
 				_contentCache = value;
 				if (oldCache != null)
+				{
 					RemoveLogicalChild(oldCache);
+				}
 
 				if (value != null && value.Parent != this)
 				{
@@ -195,7 +217,9 @@ namespace Microsoft.Maui.Controls
 				}
 
 				if (Parent != null)
+				{
 					((ShellSection)Parent).UpdateDisplayedPage();
+				}
 			}
 		}
 
@@ -243,21 +267,29 @@ namespace Microsoft.Maui.Controls
 			}
 
 			if (shellContent.Parent?.Parent is ShellItem shellItem)
+			{
 				shellItem.SendStructureChanged();
+			}
 		}
 
 		void MenuItemsCollectionChanged(object sender, NotifyCollectionChangedEventArgs e)
 		{
 			if (e.NewItems != null)
+			{
 				foreach (Element el in e.NewItems)
+				{
 					OnChildAdded(el);
+				}
+			}
 
 			if (e.OldItems != null)
+			{
 				for (var i = 0; i < e.OldItems.Count; i++)
 				{
 					var el = (Element)e.OldItems[i];
 					OnChildRemoved(el, e.OldStartingIndex + i);
 				}
+			}
 		}
 
 		internal override void ApplyQueryAttributes(ShellRouteParameters query)
@@ -269,12 +301,16 @@ namespace Microsoft.Maui.Controls
 			// An empty query is only valid if we've previously propagated
 			// something to this bindable property
 			if (query.Count == 0 && !this.IsSet(QueryAttributesProperty))
+			{
 				return;
+			}
 
 			SetValue(QueryAttributesProperty, query);
 
 			if (ContentCache is BindableObject bindable)
+			{
 				bindable.SetValue(QueryAttributesProperty, query);
+			}
 		}
 
 		static void OnQueryAttributesPropertyChanged(BindableObject bindable, object oldValue, object newValue)
@@ -294,7 +330,9 @@ namespace Microsoft.Maui.Controls
 			}
 
 			if (content is BindableObject bindable && bindable.BindingContext != null && content != bindable.BindingContext)
+			{
 				ApplyQueryAttributes(bindable.BindingContext, query, oldQuery);
+			}
 
 			var type = content.GetType();
 			var queryPropertyAttributes = type.GetCustomAttributes(typeof(QueryPropertyAttribute), true);
@@ -323,7 +361,9 @@ namespace Microsoft.Maui.Controls
 				// Once we've applied the attributes to ContentPage lets remove the 
 				// parameters used during navigation
 				if (content is ContentPage)
+				{
 					query.ResetToQueryParameters();
+				}
 			}
 		}
 
@@ -340,7 +380,9 @@ namespace Microsoft.Maui.Controls
 					if (prop.PropertyType == typeof(string))
 					{
 						if (value != null)
+						{
 							value = global::System.Net.WebUtility.UrlDecode((string)value);
+						}
 
 						prop.SetValue(content, value);
 					}
@@ -356,7 +398,9 @@ namespace Microsoft.Maui.Controls
 				PropertyInfo prop = content.GetType().GetRuntimeProperty(attrib.Name);
 
 				if (prop != null && prop.CanWrite && prop.SetMethod.IsPublic)
+				{
 					prop.SetValue(content, null);
+				}
 			}
 		}
 	}

--- a/src/Core/src/ILLink.Substitutions.xml
+++ b/src/Core/src/ILLink.Substitutions.xml
@@ -3,6 +3,8 @@
     <type fullname="Microsoft.Maui.RuntimeFeature">
       <method signature="System.Boolean get_IsXamlRuntimeParsingSupported()" body="stub" feature="Microsoft.Maui.RuntimeFeature.IsXamlRuntimeParsingSupported" value="false" featurevalue="false" />
       <method signature="System.Boolean get_IsXamlRuntimeParsingSupported()" body="stub" feature="Microsoft.Maui.RuntimeFeature.IsXamlRuntimeParsingSupported" value="true" featurevalue="true" />
+      <method signature="System.Boolean get_IsQueryPropertyAttributeSupported()" body="stub" feature="Microsoft.Maui.RuntimeFeature.IsQueryPropertyAttributeSupported" value="false" featurevalue="false" />
+      <method signature="System.Boolean get_IsQueryPropertyAttributeSupported()" body="stub" feature="Microsoft.Maui.RuntimeFeature.IsQueryPropertyAttributeSupported" value="true" featurevalue="true" />
     </type>
   </assembly>
 </linker>

--- a/src/Core/src/RuntimeFeature.cs
+++ b/src/Core/src/RuntimeFeature.cs
@@ -15,10 +15,16 @@ namespace Microsoft.Maui
 	internal static class RuntimeFeature
 	{
 		private const bool IsXamlRuntimeParsingSupportedByDefault = true;
+		private const bool IsQueryPropertyAttributeSupportedByDefault = true;
 
 		internal static bool IsXamlRuntimeParsingSupported
 			=> AppContext.TryGetSwitch("Microsoft.Maui.RuntimeFeature.IsXamlRuntimeParsingSupported", out bool isEnabled)
 				? isEnabled
 				: IsXamlRuntimeParsingSupportedByDefault;
+
+		internal static bool IsQueryPropertyAttributeSupported =>
+			AppContext.TryGetSwitch("Microsoft.Maui.RuntimeFeature.IsQueryPropertyAttributeSupported", out bool isSupported)
+				? isSupported
+				: IsQueryPropertyAttributeSupportedByDefault;
 	}
 }


### PR DESCRIPTION
WIP: This PR will be rebased on `net9.0` and moved to the official MAUI repo once #19310 is merged

### Description of Change

The current implementation of `ShellContent.ApplyQueryAttributes` isn't trimming-safe. It looks up a property using reflection by a name specified in the attribute. It then invokes the setter on the property. The trimmer can't guarantee that the property won't be trimmed.

Customers should instead implement the `IQueryAttributable` interface as described in the docs: https://learn.microsoft.com/en-us/dotnet/maui/fundamentals/shell/navigation?view=net-maui-8.0#process-navigation-data-using-a-single-method

The support for QueryParameterAttribute would be disabled for NativeAOT apps by default. Customers who need this feature can enable the feature and manually ensure that the properties are preserved by the trimmer (e.g. by adding `[DynamicallyAccessedMembers]` to the content page class or the binding context class.

### Follow-ups

- Update documentation (see Loop)
- Consider adding a code analyzer/fixer or code generator to automatically generate `IQueryAttributable` for classes with the `[QueryParameter(...)]` attribute(s)

### Issues Fixed

Contributes to #19397 
