### PR TITLE
[Trimming] Feature switch: IVisual scanning support

### DIFF
--- a/docs/design/FeatureSwitches.md
+++ b/docs/design/FeatureSwitches.md
@@ -5,6 +5,7 @@ Certain features of MAUI can be enabled or disabled using feature switches. The 
 | MSBuild Property Name | AppContext Setting | Description |
 |-|-|-|
 | MauiXamlRuntimeParsingSupport | Microsoft.Maui.RuntimeFeature.IsXamlRuntimeParsingSupported | When disabled, all XAML loading at runtime will throw an exception. This will affect usage of APIs such as the `LoadFromXaml` extension method. This feature can be safely turned off when all XAML resources are compiled using XamlC (see [XAML compilation](https://learn.microsoft.com/en-us/dotnet/maui/xaml/xamlc)). This feature is enabled by default for all configurations except for NativeAOT. |
+| MauiIVisualScanningSupport | Microsoft.Maui.RuntimeFeature.IsIVisualScanningSupported | When disabled, only visuals manually registered through `[assembly: Visual(...)]` will be available at runtime. |
 
 ## MauiXamlRuntimeParsingSupport
 

--- a/src/Controls/src/Build.Tasks/nuget/buildTransitive/netstandard2.0/Microsoft.Maui.Controls.targets
+++ b/src/Controls/src/Build.Tasks/nuget/buildTransitive/netstandard2.0/Microsoft.Maui.Controls.targets
@@ -209,11 +209,16 @@
   <Target Name="_MauiPrepareForILLink" BeforeTargets="PrepareForILLink">
     <PropertyGroup>
       <MauiXamlRuntimeParsingSupport Condition="'$(MauiXamlRuntimeParsingSupport)' == '' and '$(PublishAot)' == 'true'">false</MauiXamlRuntimeParsingSupport>
+      <MauiIVisualScanningSupport Condition="'$(MauiIVisualScanningSupport)' == '' and '$(PublishAot)' == 'true'">false</MauiIVisualScanningSupport>
     </PropertyGroup>
     <ItemGroup>
       <RuntimeHostConfigurationOption Include="Microsoft.Maui.RuntimeFeature.IsXamlRuntimeParsingSupported"
                                       Condition="'$(MauiXamlRuntimeParsingSupport)' != ''"
                                       Value="$(MauiXamlRuntimeParsingSupport)"
+                                      Trim="true" />
+      <RuntimeHostConfigurationOption Include="Microsoft.Maui.RuntimeFeature.IsIVisualScanningSupported"
+                                      Condition="'$(MauiIVisualScanningSupport)' != ''"
+                                      Value="$(MauiIVisualScanningSupport)"
                                       Trim="true" />
     </ItemGroup>
   </Target>

--- a/src/Controls/src/Core/Visuals/VisualMarker.cs
+++ b/src/Controls/src/Core/Visuals/VisualMarker.cs
@@ -39,14 +39,20 @@ namespace Microsoft.Maui.Controls
 		internal static void MaterialCheck()
 		{
 			if (_isMaterialRegistered || _warnedAboutMaterial)
+			{
 				return;
+			}
 
 			var logger = Application.Current?.FindMauiContext()?.CreateLogger<IVisual>();
 			_warnedAboutMaterial = true;
 			if (DeviceInfo.Platform == DevicePlatform.iOS || DeviceInfo.Platform == DevicePlatform.Android || DeviceInfo.Platform == DevicePlatform.Tizen)
+			{
 				logger?.LogWarning("Material needs to be registered on {RuntimePlatform} by calling FormsMaterial.Init() after the Microsoft.Maui.Controls.Forms.Init method call.", DeviceInfo.Platform);
+			}
 			else
+			{
 				logger?.LogWarning("Material is currently not support on {RuntimePlatform}.", DeviceInfo.Platform);
+			}
 		}
 
 		internal sealed class MaterialVisual : IVisual { public MaterialVisual() { } }

--- a/src/Controls/src/Core/Visuals/VisualMarker.cs
+++ b/src/Controls/src/Core/Visuals/VisualMarker.cs
@@ -3,6 +3,21 @@ using System.ComponentModel;
 using Microsoft.Extensions.Logging;
 using Microsoft.Maui.Devices;
 
+[assembly: Microsoft.Maui.Controls.Visual("Material", typeof(Microsoft.Maui.Controls.VisualMarker.MaterialVisual))]
+[assembly: Microsoft.Maui.Controls.Visual("MaterialVisual", typeof(Microsoft.Maui.Controls.VisualMarker.MaterialVisual))]
+[assembly: Microsoft.Maui.Controls.Visual("Microsoft.Maui.Controls.Material", typeof(Microsoft.Maui.Controls.VisualMarker.MaterialVisual))]
+[assembly: Microsoft.Maui.Controls.Visual("Microsoft.Maui.Controls.MaterialVisual", typeof(Microsoft.Maui.Controls.VisualMarker.MaterialVisual))]
+
+[assembly: Microsoft.Maui.Controls.Visual("Default", typeof(Microsoft.Maui.Controls.VisualMarker.DefaultVisual))]
+[assembly: Microsoft.Maui.Controls.Visual("DefaultVisual", typeof(Microsoft.Maui.Controls.VisualMarker.DefaultVisual))]
+[assembly: Microsoft.Maui.Controls.Visual("Microsoft.Maui.Controls.Default", typeof(Microsoft.Maui.Controls.VisualMarker.DefaultVisual))]
+[assembly: Microsoft.Maui.Controls.Visual("Microsoft.Maui.Controls.DefaultVisual", typeof(Microsoft.Maui.Controls.VisualMarker.DefaultVisual))]
+
+[assembly: Microsoft.Maui.Controls.Visual("MatchParent", typeof(Microsoft.Maui.Controls.VisualMarker.MatchParentVisual))]
+[assembly: Microsoft.Maui.Controls.Visual("MatchParentVisual", typeof(Microsoft.Maui.Controls.VisualMarker.MatchParentVisual))]
+[assembly: Microsoft.Maui.Controls.Visual("Microsoft.Maui.Controls.MatchParent", typeof(Microsoft.Maui.Controls.VisualMarker.MatchParentVisual))]
+[assembly: Microsoft.Maui.Controls.Visual("Microsoft.Maui.Controls.MatchParentVisual", typeof(Microsoft.Maui.Controls.VisualMarker.MatchParentVisual))]
+
 namespace Microsoft.Maui.Controls
 {
 	/// <include file="../../../docs/Microsoft.Maui.Controls/VisualMarker.xml" path="Type[@FullName='Microsoft.Maui.Controls.VisualMarker']/Docs/*" />

--- a/src/Controls/src/Core/Visuals/VisualTypeConverter.cs
+++ b/src/Controls/src/Core/Visuals/VisualTypeConverter.cs
@@ -37,11 +37,17 @@ namespace Microsoft.Maui.Controls
 			// Check for visual assembly attributes	after scanning for IVisual Types
 			// this will let users replace the default visual names if they want to
 			foreach (var assembly in assemblies)
+			{
 				RegisterFromAttributes(assembly, mappings);
+			}
 
 			if (Internals.Registrar.ExtraAssemblies != null)
+			{
 				foreach (var assembly in Internals.Registrar.ExtraAssemblies)
+				{
 					RegisterFromAttributes(assembly, mappings);
+				}
+			}
 
 			_visualTypeMappings = mappings;
 		}
@@ -52,11 +58,17 @@ namespace Microsoft.Maui.Controls
 		static void ScanAssemblies(Assembly[] assemblies, Dictionary<string, IVisual> mappings)
 		{
 			foreach (var assembly in assemblies)
+			{
 				Register(assembly, mappings);
+			}
 
 			if (Internals.Registrar.ExtraAssemblies != null)
+			{
 				foreach (var assembly in Internals.Registrar.ExtraAssemblies)
+				{
 					Register(assembly, mappings);
+				}
+			}
 		}
 
 		static void RegisterFromAttributes(Assembly assembly, Dictionary<string, IVisual> mappings)
@@ -69,7 +81,9 @@ namespace Microsoft.Maui.Controls
 				{
 					var visual = CreateVisual(attribute.Visual);
 					if (visual != null)
+					{
 						mappings[attribute.Key] = visual;
+					}
 				}
 			}
 		}
@@ -77,13 +91,19 @@ namespace Microsoft.Maui.Controls
 		static void Register(Assembly assembly, Dictionary<string, IVisual> mappings)
 		{
 			if (assembly.IsDynamic)
+			{
 				return;
+			}
 
 			try
 			{
 				foreach (var type in assembly.GetExportedTypes())
+				{
 					if (typeof(IVisual).IsAssignableFrom(type) && type != typeof(IVisual))
+					{
 						Register(type, mappings);
+					}
+				}
 			}
 			catch (NotSupportedException)
 			{
@@ -105,7 +125,9 @@ namespace Microsoft.Maui.Controls
 		{
 			IVisual registeredVisual = CreateVisual(visual);
 			if (registeredVisual == null)
+			{
 				return;
+			}
 
 			string name = visual.Name;
 			string fullName = visual.FullName;
@@ -141,12 +163,16 @@ namespace Microsoft.Maui.Controls
 		{
 			var strValue = value?.ToString();
 			if (_visualTypeMappings == null)
+			{
 				InitMappings();
+			}
 
 			if (strValue != null)
 			{
 				if (_visualTypeMappings.TryGetValue(strValue, out IVisual returnValue))
+				{
 					return returnValue;
+				}
 
 				return VisualMarker.Default;
 			}
@@ -157,16 +183,25 @@ namespace Microsoft.Maui.Controls
 		public override object ConvertTo(ITypeDescriptorContext context, CultureInfo culture, object value, Type destinationType)
 		{
 			if (value is not IVisual visual)
+			{
 				throw new NotSupportedException();
+			}
 
 			if (_visualTypeMappings == null)
+			{
 				InitMappings();
+			}
 
 			if (visual == VisualMarker.Default)
+			{
 				return "default";
+			}
 
 			if (_visualTypeMappings.ContainsValue(visual))
+			{
 				return _visualTypeMappings.Keys.Skip(_visualTypeMappings.Values.IndexOf(visual)).First();
+			}
+
 			throw new NotSupportedException();
 		}
 

--- a/src/Controls/src/Core/Visuals/VisualTypeConverter.cs
+++ b/src/Controls/src/Core/Visuals/VisualTypeConverter.cs
@@ -28,14 +28,11 @@ namespace Microsoft.Maui.Controls
 			var mappings = new Dictionary<string, IVisual>(StringComparer.OrdinalIgnoreCase);
 			Assembly[] assemblies = AppDomain.CurrentDomain.GetAssemblies();
 
-			// Check for IVisual Types
-			foreach (var assembly in assemblies)
-				Register(assembly, mappings);
-
-			if (Internals.Registrar.ExtraAssemblies != null)
-				foreach (var assembly in Internals.Registrar.ExtraAssemblies)
-					Register(assembly, mappings);
-
+			if (RuntimeFeature.IsIVisualScanningSupported)
+			{
+				// Check for IVisual Types
+				ScanAssemblies(assemblies, mappings);
+			}
 
 			// Check for visual assembly attributes	after scanning for IVisual Types
 			// this will let users replace the default visual names if they want to
@@ -47,6 +44,19 @@ namespace Microsoft.Maui.Controls
 					RegisterFromAttributes(assembly, mappings);
 
 			_visualTypeMappings = mappings;
+		}
+
+		[RequiresUnreferencedCode("The IVisual types might be removed by trimming. "
+			+ "Use the [assembly: Visual(\"key\", typeof(MyIVisual))] attribute to explicitly register the IVisual types instead.",
+			Url = "TODO")]
+		static void ScanAssemblies(Assembly[] assemblies, Dictionary<string, IVisual> mappings)
+		{
+			foreach (var assembly in assemblies)
+				Register(assembly, mappings);
+
+			if (Internals.Registrar.ExtraAssemblies != null)
+				foreach (var assembly in Internals.Registrar.ExtraAssemblies)
+					Register(assembly, mappings);
 		}
 
 		static void RegisterFromAttributes(Assembly assembly, Dictionary<string, IVisual> mappings)

--- a/src/Core/src/ILLink.Substitutions.xml
+++ b/src/Core/src/ILLink.Substitutions.xml
@@ -3,6 +3,8 @@
     <type fullname="Microsoft.Maui.RuntimeFeature">
       <method signature="System.Boolean get_IsXamlRuntimeParsingSupported()" body="stub" feature="Microsoft.Maui.RuntimeFeature.IsXamlRuntimeParsingSupported" value="false" featurevalue="false" />
       <method signature="System.Boolean get_IsXamlRuntimeParsingSupported()" body="stub" feature="Microsoft.Maui.RuntimeFeature.IsXamlRuntimeParsingSupported" value="true" featurevalue="true" />
+      <method signature="System.Boolean get_IsIVisualScanningSupported()" body="stub" feature="Microsoft.Maui.RuntimeFeature.IsIVisualScanningSupported" value="false" featurevalue="false" />
+      <method signature="System.Boolean get_IsIVisualScanningSupported()" body="stub" feature="Microsoft.Maui.RuntimeFeature.IsIVisualScanningSupported" value="true" featurevalue="true" />
     </type>
   </assembly>
 </linker>

--- a/src/Core/src/RuntimeFeature.cs
+++ b/src/Core/src/RuntimeFeature.cs
@@ -15,10 +15,16 @@ namespace Microsoft.Maui
 	internal static class RuntimeFeature
 	{
 		private const bool IsXamlRuntimeParsingSupportedByDefault = true;
+		private const bool IsIVisualScanningSupportedByDefault = true;
 
 		internal static bool IsXamlRuntimeParsingSupported
 			=> AppContext.TryGetSwitch("Microsoft.Maui.RuntimeFeature.IsXamlRuntimeParsingSupported", out bool isEnabled)
 				? isEnabled
 				: IsXamlRuntimeParsingSupportedByDefault;
+
+		internal static bool IsIVisualScanningSupported =>
+			AppContext.TryGetSwitch("Microsoft.Maui.RuntimeFeature.IsIVisualScanningSupported", out bool isSupported)
+				? isSupported
+				: IsIVisualScanningSupportedByDefault;
 	}
 }

--- a/src/TestUtils/src/Microsoft.Maui.IntegrationTests/Utilities/BuildWarningsUtilities.cs
+++ b/src/TestUtils/src/Microsoft.Maui.IntegrationTests/Utilities/BuildWarningsUtilities.cs
@@ -411,7 +411,9 @@ namespace Microsoft.Maui.IntegrationTests
 			var indent = string.Empty.PadLeft(indentSpaces);
 			var file = wpf.File;
 			if (!string.IsNullOrEmpty(repoRoot) && wpf.File.StartsWith(repoRoot))
+			{
 				file = wpf.File.Substring(repoRoot.Length);
+			}
 
 			Console.WriteLine(indent + "new WarningsPerFile");
 			Console.WriteLine(indent + "{");

--- a/src/TestUtils/src/Microsoft.Maui.IntegrationTests/Utilities/BuildWarningsUtilities.cs
+++ b/src/TestUtils/src/Microsoft.Maui.IntegrationTests/Utilities/BuildWarningsUtilities.cs
@@ -168,6 +168,38 @@ namespace Microsoft.Maui.IntegrationTests
 							"Microsoft.Maui.Controls.Xaml.TypeConversionExtensions.GetImplicitConversionOperator(Type,Type,Type): 'this' argument does not satisfy 'DynamicallyAccessedMemberTypes.PublicMethods' in call to 'System.Type.GetMethods(BindingFlags)'. The parameter '#0' of method 'Microsoft.Maui.Controls.Xaml.TypeConversionExtensions.GetImplicitConversionOperator(Type,Type,Type)' does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to.",
 						}
 					},
+					new WarningsPerCode
+					{
+						Code = "IL2072",
+						Messages = new List<string>
+						{
+							"Microsoft.Maui.Controls.Xaml.TypeConversionExtensions.<>c__DisplayClass2_0.<ConvertTo>b__0(): 'type' argument does not satisfy 'DynamicallyAccessedMemberTypes.PublicParameterlessConstructor' in call to 'System.Activator.CreateInstance(Type)'. The return value of method 'Microsoft.Maui.Controls.Xaml.TypeConversionExtensions.GetTypeConverterType(IEnumerable`1<CustomAttributeData>)' does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to.",
+							"Microsoft.Maui.Controls.Xaml.TypeConversionExtensions.<>c__DisplayClass2_0.<ConvertTo>b__0(): 'type' argument does not satisfy 'DynamicallyAccessedMemberTypes.PublicParameterlessConstructor' in call to 'System.Activator.CreateInstance(Type)'. The return value of method 'Microsoft.Maui.Controls.Xaml.TypeConversionExtensions.GetTypeConverterType(IEnumerable`1<CustomAttributeData>)' does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to.",
+						}
+					},
+					new WarningsPerCode
+					{
+						Code = "IL2057",
+						Messages = new List<string>
+						{
+							"Microsoft.Maui.Controls.Xaml.TypeConversionExtensions.GetTypeConverterType(IEnumerable`1<CustomAttributeData>): Unrecognized value passed to the parameter 'typeName' of method 'System.Type.GetType(String)'. It's not possible to guarantee the availability of the target type.",
+						}
+					},
+				}
+			},
+			new WarningsPerFile
+			{
+				File = "src/Controls/src/Core/Routing.cs",
+				WarningsPerCode = new List<WarningsPerCode>
+				{
+					new WarningsPerCode
+					{
+						Code = "IL2111",
+						Messages = new List<string>
+						{
+							"Microsoft.Maui.Controls.Routing..cctor(): Method 'Microsoft.Maui.Controls.Routing.RegisterRoute(String,Type)' with parameters or return value with `DynamicallyAccessedMembersAttribute` is accessed via reflection. Trimmer can't guarantee availability of the requirements of the method.",
+						}
+					},
 				}
 			},
 			new WarningsPerFile


### PR DESCRIPTION
WIP: This PR will be rebased on main and moved to the official MAUI repo once https://github.com/dotnet/maui/pull/19310 is merged

### Description of Change
The current implementation of `VisualTypeConverter.InitMappings` isn't trimming-safe. It scans all types in all assemblies and looks for classes implementing the `IVisual` interface. 

Customers should instead use the existing `[assembly: Visual(...)]` attribute to register their `IVisual` classes.

TODO: We need a follow-up issue to update the docs -- although I can only find Xamarin Forms docs... where are the MAUI docs?
TODO: Link to docs

### Issues Fixed
Contributes to https://github.com/dotnet/maui/issues/19397, fixes https://github.com/dotnet/maui/issues/4937