### PR TITLE
Add benchmark for source-generated SetBinding

### DIFF
--- a/src/Controls/src/BindingSourceGen/BindingSourceGenerator.cs
+++ b/src/Controls/src/BindingSourceGen/BindingSourceGenerator.cs
@@ -109,7 +109,7 @@ public class BindingSourceGenerator : IIncrementalGenerator
 	private static EquatableArray<DiagnosticInfo> VerifyCorrectOverload(InvocationExpressionSyntax invocation, GeneratorSyntaxContext context, CancellationToken t)
 	{
 		var argumentList = invocation.ArgumentList.Arguments;
-		
+
 		if (argumentList.Count < 2)
 		{
 			throw new ArgumentOutOfRangeException(nameof(invocation));

--- a/src/Controls/src/BindingSourceGen/BindingSourceGenerator.cs
+++ b/src/Controls/src/BindingSourceGen/BindingSourceGenerator.cs
@@ -111,7 +111,8 @@ public class BindingSourceGenerator : IIncrementalGenerator
 		var argumentList = invocation.ArgumentList.Arguments;
 		var secondArgument = argumentList[1].Expression;
 
-		if (secondArgument is IdentifierNameSyntax) {
+		if (secondArgument is IdentifierNameSyntax)
+		{
 			var type = context.SemanticModel.GetTypeInfo(secondArgument, cancellationToken: t).Type;
 			if (type != null && type.Name == "Func")
 			{

--- a/src/Controls/src/BindingSourceGen/BindingSourceGenerator.cs
+++ b/src/Controls/src/BindingSourceGen/BindingSourceGenerator.cs
@@ -49,7 +49,10 @@ public class BindingSourceGenerator : IIncrementalGenerator
 	{
 		return node is InvocationExpressionSyntax invocation
 			&& invocation.Expression is MemberAccessExpressionSyntax method
-			&& method.Name.Identifier.Text == "SetBinding";
+			&& method.Name.Identifier.Text == "SetBinding"
+			&& invocation.ArgumentList.Arguments.Count >= 2
+			&& invocation.ArgumentList.Arguments[1].Expression is not LiteralExpressionSyntax
+			&& invocation.ArgumentList.Arguments[1].Expression is not ObjectCreationExpressionSyntax;
 	}
 
 	static BindingDiagnosticsWrapper GetBindingForGeneration(GeneratorSyntaxContext context, CancellationToken t)

--- a/src/Controls/src/BindingSourceGen/BindingSourceGenerator.cs
+++ b/src/Controls/src/BindingSourceGen/BindingSourceGenerator.cs
@@ -109,6 +109,12 @@ public class BindingSourceGenerator : IIncrementalGenerator
 	private static EquatableArray<DiagnosticInfo> VerifyCorrectOverload(InvocationExpressionSyntax invocation, GeneratorSyntaxContext context, CancellationToken t)
 	{
 		var argumentList = invocation.ArgumentList.Arguments;
+		
+		if (argumentList.Count < 2)
+		{
+			throw new ArgumentOutOfRangeException(nameof(invocation));
+		}
+
 		var secondArgument = argumentList[1].Expression;
 
 		if (secondArgument is IdentifierNameSyntax)

--- a/src/Controls/src/BindingSourceGen/DiagnosticsFactory.cs
+++ b/src/Controls/src/BindingSourceGen/DiagnosticsFactory.cs
@@ -56,7 +56,7 @@ internal static class DiagnosticsFactory
                 title: "SetBinding with string path",
                 messageFormat: "TODO: consider using SetBinding overload with a lambda getter",
                 category: "Usage",
-                defaultSeverity: DiagnosticSeverity.Warning,
-                isEnabledByDefault: true),
+                defaultSeverity: DiagnosticSeverity.Hidden,
+                isEnabledByDefault: false),
             location);
 }

--- a/src/Controls/src/BindingSourceGen/DiagnosticsFactory.cs
+++ b/src/Controls/src/BindingSourceGen/DiagnosticsFactory.cs
@@ -4,59 +4,59 @@ namespace Microsoft.Maui.Controls.BindingSourceGen;
 
 public sealed record DiagnosticInfo
 {
-    public DiagnosticInfo(DiagnosticDescriptor descriptor, Location? location)
-    {
-        Descriptor = descriptor;
-        Location = location is not null ? SourceCodeLocation.CreateFrom(location) : null;
-    }
+	public DiagnosticInfo(DiagnosticDescriptor descriptor, Location? location)
+	{
+		Descriptor = descriptor;
+		Location = location is not null ? SourceCodeLocation.CreateFrom(location) : null;
+	}
 
-    public DiagnosticDescriptor Descriptor { get; }
-    public SourceCodeLocation? Location { get; }
+	public DiagnosticDescriptor Descriptor { get; }
+	public SourceCodeLocation? Location { get; }
 }
 
 internal static class DiagnosticsFactory
 {
-    public static DiagnosticInfo UnableToResolvePath(Location location)
-        => new(
-            new DiagnosticDescriptor(
-                id: "BSG0001",
-                title: "Unable to resolve path",
-                messageFormat: "TODO: unable to resolve path",
-                category: "Usage",
-                defaultSeverity: DiagnosticSeverity.Error,
-                isEnabledByDefault: true),
-            location);
+	public static DiagnosticInfo UnableToResolvePath(Location location)
+		=> new(
+			new DiagnosticDescriptor(
+				id: "BSG0001",
+				title: "Unable to resolve path",
+				messageFormat: "TODO: unable to resolve path",
+				category: "Usage",
+				defaultSeverity: DiagnosticSeverity.Error,
+				isEnabledByDefault: true),
+			location);
 
-    public static DiagnosticInfo GetterIsNotLambda(Location location)
-        => new(
-            new DiagnosticDescriptor(
-                id: "BSG0002",
-                title: "Getter must be a lambda",
-                messageFormat: "TODO: getter must be a lambda",
-                category: "Usage",
-                defaultSeverity: DiagnosticSeverity.Error,
-                isEnabledByDefault: true),
-            location);
+	public static DiagnosticInfo GetterIsNotLambda(Location location)
+		=> new(
+			new DiagnosticDescriptor(
+				id: "BSG0002",
+				title: "Getter must be a lambda",
+				messageFormat: "TODO: getter must be a lambda",
+				category: "Usage",
+				defaultSeverity: DiagnosticSeverity.Error,
+				isEnabledByDefault: true),
+			location);
 
-    public static DiagnosticInfo GetterLambdaBodyIsNotExpression(Location location)
-        => new(
-            new DiagnosticDescriptor(
-                id: "BSG0003",
-                title: "Getter lambda's body must be an expression",
-                messageFormat: "TODO: getter lambda's body must be an expression",
-                category: "Usage",
-                defaultSeverity: DiagnosticSeverity.Error,
-                isEnabledByDefault: true),
-            location);
+	public static DiagnosticInfo GetterLambdaBodyIsNotExpression(Location location)
+		=> new(
+			new DiagnosticDescriptor(
+				id: "BSG0003",
+				title: "Getter lambda's body must be an expression",
+				messageFormat: "TODO: getter lambda's body must be an expression",
+				category: "Usage",
+				defaultSeverity: DiagnosticSeverity.Error,
+				isEnabledByDefault: true),
+			location);
 
-    public static DiagnosticInfo SuboptimalSetBindingOverload(Location location)
-        => new(
-            new DiagnosticDescriptor(
-                id: "BSG0004",
-                title: "SetBinding with string path",
-                messageFormat: "TODO: consider using SetBinding overload with a lambda getter",
-                category: "Usage",
-                defaultSeverity: DiagnosticSeverity.Hidden,
-                isEnabledByDefault: false),
-            location);
+	public static DiagnosticInfo SuboptimalSetBindingOverload(Location location)
+		=> new(
+			new DiagnosticDescriptor(
+				id: "BSG0004",
+				title: "SetBinding with string path",
+				messageFormat: "TODO: consider using SetBinding overload with a lambda getter",
+				category: "Usage",
+				defaultSeverity: DiagnosticSeverity.Hidden,
+				isEnabledByDefault: false),
+			location);
 }

--- a/src/Controls/tests/BindingSourceGen.UnitTests/DiagnosticsTests.cs
+++ b/src/Controls/tests/BindingSourceGen.UnitTests/DiagnosticsTests.cs
@@ -4,10 +4,10 @@ namespace BindingSourceGen.UnitTests;
 
 public class DiagnosticsTests
 {
-    [Fact]
-    public void ReportsErrorWhenGetterIsNotLambda()
-    {
-        var source = """
+	[Fact]
+	public void ReportsErrorWhenGetterIsNotLambda()
+	{
+		var source = """
             using System;
             using Microsoft.Maui.Controls;
             var label = new Label();
@@ -15,44 +15,44 @@ public class DiagnosticsTests
             label.SetBinding(Label.RotationProperty, getter);
             """;
 
-        var result = SourceGenHelpers.Run(source);
-        Assert.Single(result.SourceGeneratorDiagnostics);
-        Assert.Equal("BSG0002", result.SourceGeneratorDiagnostics[0].Id);
-    }
+		var result = SourceGenHelpers.Run(source);
+		Assert.Single(result.SourceGeneratorDiagnostics);
+		Assert.Equal("BSG0002", result.SourceGeneratorDiagnostics[0].Id);
+	}
 
-    [Fact]
-    public void ReportsErrorWhenLambdaBodyIsNotExpression()
-    {
-        var source = """
+	[Fact]
+	public void ReportsErrorWhenLambdaBodyIsNotExpression()
+	{
+		var source = """
             using Microsoft.Maui.Controls;
             var label = new Label();
             label.SetBinding(Label.RotationProperty, static (Button b) => { return b.Text.Length; });
             """;
 
-        var result = SourceGenHelpers.Run(source);
+		var result = SourceGenHelpers.Run(source);
 
-        Assert.Single(result.SourceGeneratorDiagnostics);
-        Assert.Equal("BSG0003", result.SourceGeneratorDiagnostics[0].Id);
-    }
+		Assert.Single(result.SourceGeneratorDiagnostics);
+		Assert.Equal("BSG0003", result.SourceGeneratorDiagnostics[0].Id);
+	}
 
-    [Fact]
-    public void DoesNotReportWarningWhenUsingOverloadWithBindingClassDeclaredInInvocation()
-    {
-        var source = """
+	[Fact]
+	public void DoesNotReportWarningWhenUsingOverloadWithBindingClassDeclaredInInvocation()
+	{
+		var source = """
             using Microsoft.Maui.Controls;
             var label = new Label();
             var slider = new Slider();
             label.SetBinding(Label.ScaleProperty, new Binding("Value", source: slider));
             """;
 
-        var result = SourceGenHelpers.Run(source);
-        Assert.Empty(result.SourceGeneratorDiagnostics);
-    }
+		var result = SourceGenHelpers.Run(source);
+		Assert.Empty(result.SourceGeneratorDiagnostics);
+	}
 
-    [Fact]
-    public void DoesNotReportWarningWhenUsingOverloadWithBindingClassPassedAsVariable()
-    {
-        var source = """
+	[Fact]
+	public void DoesNotReportWarningWhenUsingOverloadWithBindingClassPassedAsVariable()
+	{
+		var source = """
             using Microsoft.Maui.Controls;
             var label = new Label();
             var slider = new Slider();
@@ -60,14 +60,14 @@ public class DiagnosticsTests
             label.SetBinding(Label.ScaleProperty, binding);
             """;
 
-        var result = SourceGenHelpers.Run(source);
-        Assert.Empty(result.SourceGeneratorDiagnostics);
-    }
+		var result = SourceGenHelpers.Run(source);
+		Assert.Empty(result.SourceGeneratorDiagnostics);
+	}
 
-    [Fact]
-    public void DoesNotReportWarningWhenUsingOverloadWithStringConstantPath()
-    {
-        var source = """
+	[Fact]
+	public void DoesNotReportWarningWhenUsingOverloadWithStringConstantPath()
+	{
+		var source = """
             using Microsoft.Maui.Controls;
             var label = new Label();
             var slider = new Slider();
@@ -76,14 +76,14 @@ public class DiagnosticsTests
             label.SetBinding(Label.ScaleProperty, "Value");
             """;
 
-        var result = SourceGenHelpers.Run(source);
-        Assert.Empty(result.SourceGeneratorDiagnostics);
-    }
+		var result = SourceGenHelpers.Run(source);
+		Assert.Empty(result.SourceGeneratorDiagnostics);
+	}
 
-    [Fact]
-    public void DoesNotReportWarningWhenUsingOverloadWithStringVariablePath()
-    {
-        var source = """
+	[Fact]
+	public void DoesNotReportWarningWhenUsingOverloadWithStringVariablePath()
+	{
+		var source = """
             using Microsoft.Maui.Controls;
             var label = new Label();
             var slider = new Slider();
@@ -93,14 +93,14 @@ public class DiagnosticsTests
             label.SetBinding(Label.ScaleProperty, str);
             """;
 
-        var result = SourceGenHelpers.Run(source);
-        Assert.Empty(result.SourceGeneratorDiagnostics);
-    }
-    
-    [Fact]
-    public void ReportsUnableToResolvePathWhenUsingMethodCall()
-    {
-        var source = """
+		var result = SourceGenHelpers.Run(source);
+		Assert.Empty(result.SourceGeneratorDiagnostics);
+	}
+
+	[Fact]
+	public void ReportsUnableToResolvePathWhenUsingMethodCall()
+	{
+		var source = """
             using Microsoft.Maui.Controls;
 
             double GetRotation(Button b) => b.Rotation;
@@ -109,16 +109,16 @@ public class DiagnosticsTests
             label.SetBinding(Label.RotationProperty, (Button b) => GetRotation(b));
             """;
 
-        var result = SourceGenHelpers.Run(source);
+		var result = SourceGenHelpers.Run(source);
 
-        Assert.Single(result.SourceGeneratorDiagnostics);
-        Assert.Equal("BSG0001", result.SourceGeneratorDiagnostics[0].Id);
-    }
+		Assert.Single(result.SourceGeneratorDiagnostics);
+		Assert.Equal("BSG0001", result.SourceGeneratorDiagnostics[0].Id);
+	}
 
-    [Fact]
-    public void ReportsUnableToResolvePathWhenUsingMultidimensionalArray()
-    {
-        var source = """
+	[Fact]
+	public void ReportsUnableToResolvePathWhenUsingMultidimensionalArray()
+	{
+		var source = """
             using Microsoft.Maui.Controls;
             var label = new Label();
 
@@ -126,9 +126,9 @@ public class DiagnosticsTests
             label.SetBinding(Label.RotationProperty, (Button b) => array[0, 0]);
             """;
 
-        var result = SourceGenHelpers.Run(source);
+		var result = SourceGenHelpers.Run(source);
 
-        Assert.Single(result.SourceGeneratorDiagnostics);
-        Assert.Equal("BSG0001", result.SourceGeneratorDiagnostics[0].Id);
-    }
+		Assert.Single(result.SourceGeneratorDiagnostics);
+		Assert.Equal("BSG0001", result.SourceGeneratorDiagnostics[0].Id);
+	}
 }

--- a/src/Controls/tests/BindingSourceGen.UnitTests/DiagnosticsTests.cs
+++ b/src/Controls/tests/BindingSourceGen.UnitTests/DiagnosticsTests.cs
@@ -36,7 +36,7 @@ public class DiagnosticsTests
     }
 
     [Fact]
-    public void DoesNotReportWarningWhenUsingOverloadWithBindingClass()
+    public void DoesNotReportWarningWhenUsingOverloadWithBindingClassDeclaredInInvocation()
     {
         var source = """
             using Microsoft.Maui.Controls;
@@ -50,7 +50,22 @@ public class DiagnosticsTests
     }
 
     [Fact]
-    public void DoesNotReportWarningWhenUsingOverloadWithStringPath()
+    public void DoesNotReportWarningWhenUsingOverloadWithBindingClassPassedAsVariable()
+    {
+        var source = """
+            using Microsoft.Maui.Controls;
+            var label = new Label();
+            var slider = new Slider();
+            var binding = new Binding("Value", source: slider);
+            label.SetBinding(Label.ScaleProperty, binding);
+            """;
+
+        var result = SourceGenHelpers.Run(source);
+        Assert.Empty(result.SourceGeneratorDiagnostics);
+    }
+
+    [Fact]
+    public void DoesNotReportWarningWhenUsingOverloadWithStringConstantPath()
     {
         var source = """
             using Microsoft.Maui.Controls;
@@ -59,6 +74,23 @@ public class DiagnosticsTests
 
             label.BindingContext = slider;
             label.SetBinding(Label.ScaleProperty, "Value");
+            """;
+
+        var result = SourceGenHelpers.Run(source);
+        Assert.Empty(result.SourceGeneratorDiagnostics);
+    }
+
+    [Fact]
+    public void DoesNotReportWarningWhenUsingOverloadWithStringVariablePath()
+    {
+        var source = """
+            using Microsoft.Maui.Controls;
+            var label = new Label();
+            var slider = new Slider();
+
+            label.BindingContext = slider;
+            var str = "Value";
+            label.SetBinding(Label.ScaleProperty, str);
             """;
 
         var result = SourceGenHelpers.Run(source);

--- a/src/Controls/tests/BindingSourceGen.UnitTests/DiagnosticsTests.cs
+++ b/src/Controls/tests/BindingSourceGen.UnitTests/DiagnosticsTests.cs
@@ -4,7 +4,7 @@ namespace BindingSourceGen.UnitTests;
 
 public class DiagnosticsTests
 {
-    [Fact(Skip = "Improve detecting overloads")]
+    [Fact]
     public void ReportsErrorWhenGetterIsNotLambda()
     {
         var source = """
@@ -36,7 +36,7 @@ public class DiagnosticsTests
     }
 
     [Fact]
-    public void ReportsWarningWhenUsingDifferentSetBindingOverload()
+    public void DoesNotReportWarningWhenUsingOverloadWithBindingClass()
     {
         var source = """
             using Microsoft.Maui.Controls;
@@ -46,11 +46,25 @@ public class DiagnosticsTests
             """;
 
         var result = SourceGenHelpers.Run(source);
-
-        Assert.Single(result.SourceGeneratorDiagnostics);
-        Assert.Equal("BSG0004", result.SourceGeneratorDiagnostics[0].Id);
+        Assert.Empty(result.SourceGeneratorDiagnostics);
     }
 
+    [Fact]
+    public void DoesNotReportWarningWhenUsingOverloadWithStringPath()
+    {
+        var source = """
+            using Microsoft.Maui.Controls;
+            var label = new Label();
+            var slider = new Slider();
+
+            label.BindingContext = slider;
+            label.SetBinding(Label.ScaleProperty, "Value");
+            """;
+
+        var result = SourceGenHelpers.Run(source);
+        Assert.Empty(result.SourceGeneratorDiagnostics);
+    }
+    
     [Fact]
     public void ReportsUnableToResolvePathWhenUsingMethodCall()
     {

--- a/src/Core/tests/Benchmarks/Benchmarks/SourceGeneratedBindingBenchmarker.cs
+++ b/src/Core/tests/Benchmarks/Benchmarks/SourceGeneratedBindingBenchmarker.cs
@@ -40,7 +40,7 @@ namespace Microsoft.Maui.Benchmarks
 			}
 		};
 		readonly MyObject Target = new() { Name = "B" };
-		
+
 		[Benchmark]
 		public void SourceGeneratedBindName()
 		{
@@ -49,7 +49,7 @@ namespace Microsoft.Maui.Benchmarks
 				Target.SetBinding(MyObject.NameProperty, static (MyObject o) => o.Name, source: Source, mode: BindingMode.OneWay);
 			}
 		}
-		
+
 		[Benchmark]
 		public void SourceGeneratedBindChild()
 		{
@@ -58,7 +58,7 @@ namespace Microsoft.Maui.Benchmarks
 				Target.SetBinding(MyObject.NameProperty, static (MyObject o) => o.Child?.Name, source: Source, mode: BindingMode.OneWay);
 			}
 		}
-		
+
 		[Benchmark]
 		public void SourceGeneratedBindChildIndexer()
 		{

--- a/src/Core/tests/Benchmarks/Benchmarks/SourceGeneratedBindingBenchmarker.cs
+++ b/src/Core/tests/Benchmarks/Benchmarks/SourceGeneratedBindingBenchmarker.cs
@@ -1,0 +1,71 @@
+﻿#nullable enable
+using System;
+using System.Collections.Generic;
+using BenchmarkDotNet.Attributes;
+using Microsoft.Maui.Controls;
+using Microsoft.Maui.Controls.Internals;
+
+namespace Microsoft.Maui.Benchmarks
+{
+	[MemoryDiagnoser]
+	public class SourceGeneratedBindingBenchmarker
+	{
+		// Avoids the warning:
+		// The minimum observed iteration time is 10.1000 us which is very small. It's recommended to increase it to at least 100.0000 ms using more operations.
+		const int Iterations = 10;
+
+		public class MyObject : BindableObject
+		{
+			public static readonly BindableProperty NameProperty = BindableProperty.Create(nameof(Name), typeof(string), typeof(MyObject));
+
+			public string Name
+			{
+				get { return (string)GetValue(NameProperty); }
+				set { SetValue(NameProperty, value); }
+			}
+
+			public MyObject? Child { get; set; }
+
+			public List<MyObject> Children { get; private set; } = new List<MyObject>();
+		}
+
+		readonly MyObject Source = new()
+		{
+			Name = "A",
+			Child = new() { Name = "A.Child" },
+			Children =
+			{
+				new() { Name = "A.Children[0]" },
+				new() { Name = "A.Children[1]" },
+			}
+		};
+		readonly MyObject Target = new() { Name = "B" };
+		
+		[Benchmark]
+		public void SourceGeneratedBindName()
+		{
+			for (int i = 0; i < Iterations; i++)
+			{
+				Target.SetBinding(MyObject.NameProperty, static (MyObject o) => o.Name, source: Source, mode: BindingMode.OneWay);
+			}
+		}
+		
+		[Benchmark]
+		public void SourceGeneratedBindChild()
+		{
+			for (int i = 0; i < Iterations; i++)
+			{
+				Target.SetBinding(MyObject.NameProperty, static (MyObject o) => o.Child?.Name, source: Source, mode: BindingMode.OneWay);
+			}
+		}
+		
+		[Benchmark]
+		public void SourceGeneratedBindChildIndexer()
+		{
+			for (int i = 0; i < Iterations; i++)
+			{
+				Target.SetBinding(MyObject.NameProperty, static (MyObject o) => o.Children[0].Name, source: Source, mode: BindingMode.OneWay);
+			}
+		}
+	}
+}

--- a/src/Core/tests/Benchmarks/Core.Benchmarks.csproj
+++ b/src/Core/tests/Benchmarks/Core.Benchmarks.csproj
@@ -3,6 +3,8 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>$(_MauiDotNetTfm)</TargetFramework>
+    <EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>
+    <InterceptorsPreviewNamespaces>$(InterceptorsPreviewNamespaces);Microsoft.Maui.Controls.Generated</InterceptorsPreviewNamespaces>
   </PropertyGroup>
 
   <ItemGroup>
@@ -15,6 +17,13 @@
     <ProjectReference Include="..\..\..\Controls\src\Xaml\Controls.Xaml.csproj" />
     <ProjectReference Include="..\..\..\Controls\src\Core\Controls.Core.csproj" />
     <ProjectReference Include="..\..\..\Core\src\Core.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference
+      Include="..\..\..\Controls\src\BindingSourceGen\Controls.BindingSourceGen.csproj"
+      OutputItemType="Analyzer"
+      ReferenceOutputAssembly="false" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
| Method                          | Mean     | Error    | StdDev   | Gen0   | Gen1   | Allocated |
|----------------------           |---------:|---------:|---------:|-------:|-------:|----------:|
| TypedBindName                   | 13.11 us | 0.244 us | 0.251 us | 1.2207 | 0.6104 |    7.5 KB |
| SourceGeneratedBindName         | 14.39 us | 0.137 us | 0.129 us | 1.3580 | 0.6714 |   8.36 KB |
| BindName                        | 16.98 us | 0.315 us | 0.279 us | 1.6785 | 0.8240 |  10.31 KB |
| TypedBindChild                  | 20.47 us | 0.214 us | 0.190 us | 2.0142 | 1.0071 |  12.42 KB |
| SourceGeneratedBindChild        | 21.09 us | 0.374 us | 0.349 us | 2.1667 | 1.0681 |  13.28 KB |
| BindChild                       | 21.51 us | 0.284 us | 0.266 us | 2.5940 | 1.2817 |  16.02 KB |
| TypedBindChildIndexer           | 21.78 us | 0.361 us | 0.338 us | 2.3193 | 1.1597 |  14.38 KB |
| SourceGeneratedBindChildIndexer | 22.46 us | 0.264 us | 0.247 us | 2.4719 | 1.2207 |  15.23 KB |
| BindChildIndexer                | 41.00 us | 0.459 us | 0.429 us | 4.1504 | 2.0752 |  25.55 KB |
